### PR TITLE
docs: add Tigris as S3-compatible storage backend, fix s3 region field name

### DIFF
--- a/website/docs/administrator/backup_and_migration.md
+++ b/website/docs/administrator/backup_and_migration.md
@@ -221,8 +221,26 @@ s3:
   endpoint_url: "https://s3.amazonaws.com"
   bucket: "my-ragflow-bucket"
   prefix_path: "production"
-  region: "us-east-1"
+  region_name: "us-east-1"
 ```
+
+#### Tigris configuration
+
+[Tigris](https://www.tigrisdata.com) is an S3-compatible object storage service that works with RAGFlow's `AWS_S3` backend. Set `STORAGE_IMPL=AWS_S3` in your `.env` file:
+
+```yaml
+s3:
+  access_key: "tid_YOUR_ACCESS_KEY"
+  secret_key: "tsec_YOUR_SECRET_KEY"
+  region_name: "auto"
+  endpoint_url: "https://t3.storage.dev"
+  bucket: "ragflow"
+  prefix_path: "ragflow"
+  signature_version: "v4"
+  addressing_style: "virtual"
+```
+
+See [S3 (Tigris)](/configurations#s3-tigris) for full setup instructions.
 
 ### IAM policy example
 
@@ -302,6 +320,7 @@ minio:
 
 - ✅ **MinIO** - Full support with single bucket mode
 - ✅ **AWS S3** - Full support with single bucket mode
+- ✅ **Tigris** - Full support with single bucket mode (uses `AWS_S3` backend)
 - ✅ **Alibaba OSS** - Full support with single bucket mode
 - ✅ **Azure Blob** - Uses container-based structure (different paradigm)
 - ⚠️ **OpenDAL** - Depends on underlying storage backend

--- a/website/docs/administrator/configurations.md
+++ b/website/docs/administrator/configurations.md
@@ -166,6 +166,32 @@ If you cannot download the RAGFlow Docker image, try the following mirrors.
 - `password`: The password for MinIO.
 - `host`: The MinIO serving IP *and* port inside the Docker container. Defaults to `minio:9000`.
 
+### `s3` (Tigris)
+
+To use [Tigris](https://www.tigrisdata.com) as an S3-compatible storage backend, set `STORAGE_IMPL=AWS_S3` in `.env` and configure the `s3:` section:
+
+```yaml
+s3:
+  access_key: 'tid_YOUR_ACCESS_KEY'
+  secret_key: 'tsec_YOUR_SECRET_KEY'
+  region_name: 'auto'
+  endpoint_url: 'https://t3.storage.dev'
+  bucket: 'ragflow'
+  prefix_path: 'ragflow'
+  signature_version: 'v4'
+  addressing_style: 'virtual'
+```
+
+- `access_key` / `secret_key`: Create at [console.tigris.dev](https://console.tigris.dev).
+- `region_name`: Must be `auto`.
+- `endpoint_url`: `https://t3.storage.dev`, or `https://fly.storage.tigris.dev` on Fly.io.
+- `addressing_style`: Must be `virtual`.
+- `bucket` / `prefix_path`: Optional. Enables single-bucket mode — see [Migrate from multi-bucket to single-bucket mode](/migration#migrate-from-multi-bucket-to-single-bucket-mode).
+
+When using an external storage backend, you can remove the `minio` service from `docker-compose-base.yml`.
+
+For other S3-compatible backends (AWS S3, Alibaba Cloud OSS, Azure Blob, Google Cloud Storage), see the commented examples in [service_conf.yaml.template](https://github.com/infiniflow/ragflow/blob/main/docker/service_conf.yaml.template).
+
 ### `redis`
 
 - `host`: The Redis serving IP *and* port inside the Docker container. Defaults to `redis:6379`.


### PR DESCRIPTION
## Summary

- Add Tigris configuration to the Configuration  and Backup & migration pages, using the existing `AWS_S3` backend — no code changes required.
- Fix `region` → `region_name` in the existing S3 config example in backup_and_migration.md. The code in `s3_conn.py` reads `region_name`, so the previous field name was silently ignored.

## Context

With MinIO's open-source repository archived (#13840 on infiniflow/ragflow), users need documented alternatives for object storage. Tigris is S3-compatible and works with RAGFlow's existing `AWS_S3` backend out of the box.

## Changes

- **configurations.md**: Added `### s3 (Tigris)` section after `### minio`, matching the existing reference style. Includes config block, field descriptions, and a pointer to `service_conf.yaml.template` for other S3-compatible backends.
- **backup_and_migration.md**: Added Tigris config block under single-bucket mode. Fixed `region` → `region_name` in the existing S3 example. Added Tigris to the supported backends list.

## Notes

- No new files — edits to existing docs only.
- Config field names (`access_key`, `secret_key`, `region_name`, `endpoint_url`, `bucket`, `prefix_path`, `signature_version`, `addressing_style`) verified against `rag/utils/s3_conn.py`.